### PR TITLE
Fix audio transitions and non-Windows MSU launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 *.dll
 *.tlog
 *.log
+.worktrees/
 *.idb
 
 # ROM files (copyrighted)

--- a/docs/superpowers/plans/2026-07-19-audio-transition-recovery.md
+++ b/docs/superpowers/plans/2026-07-19-audio-transition-recovery.md
@@ -1,0 +1,221 @@
+# Audio Transition Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove reproducible loss of SPC and MSU-1 audio commands during level transitions without changing guest-visible CPU-to-APU handshake semantics.
+
+**Architecture:** Treat `audio_trace` as the transport oracle: a command is only valid when an SPC read observes it before a later CPU write replaces it. First reproduce against the v0.9.5 runner revision, then compare current `main`. Implement the smallest timing correction in the shared `snesrecomp` APU boundary proven by the trace, commit it in the framework, and advance SMW’s submodule pointer.
+
+**Tech Stack:** C11, SDL2, CMake, the `snesrecomp` submodule, existing audio trace rings, Python 3 `tools/sfx_probe.py`.
+
+## Global Constraints
+
+- Preserve immediate guest CPU-to-APU visibility for real upload handshakes.
+- Do not modify `src/gen/` or use a SMW-specific timing workaround.
+- The same transition must produce zero `LOST` commands with SPC and MSU-1 music.
+- Verify normal speed and turbo.
+- Fix additional issues only when reproduced through this verification route.
+
+---
+
+### Task 1: Establish the transport failure
+
+**Files:**
+- Modify: none
+- Use: `tools/sfx_probe.py`
+- Use: `snesrecomp/runner/src/audio_trace.c`
+
+**Interfaces:**
+- Consumes: the debug server command `audio_events` and the existing `sfx_probe.py` classification.
+- Produces: a saved transition trace whose nonzero commands are classified as `LOST`, `SEEN`, or `SEEN-NOKON`.
+
+- [ ] **Step 1: Build a debug executable with the v0.9.5 runner revision**
+
+```sh
+git -C snesrecomp checkout 2ae1488ef808cdd87bd9c6fa8fa7d63a33beccc6
+cp /absolute/path/to/legal/smw.sfc smw.sfc
+bash tools/regen.sh
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build --parallel
+```
+
+Expected: the executable starts with the debug TCP service and the existing audio trace ring enabled.
+
+- [ ] **Step 2: Capture a native-SPC level transition**
+
+```sh
+python tools/sfx_probe.py mark "before SPC transition"
+# Complete one level transition with MSU-1 disabled.
+python tools/sfx_probe.py chain 8000
+```
+
+Expected before the fix: at least one nonzero `$1DFB/music` or SFX command is `LOST`; save the command output as the failing reproduction.
+
+- [ ] **Step 3: Capture an MSU-1 level transition**
+
+```sh
+SNESRECOMP_MSU1=/absolute/path/to/matching/conn-msu-pack ./build/smw
+python tools/sfx_probe.py mark "before MSU transition"
+# Complete the same level transition with MSU-1 enabled.
+python tools/sfx_probe.py chain 8000
+```
+
+Expected before the fix: the transport classification reproduces the same lost command or identifies an engine-level `SEEN-NOKON` failure.
+
+- [ ] **Step 4: Repeat with turbo**
+
+```sh
+SNESRECOMP_FORCE_TURBO=1 ./build/smw
+python tools/sfx_probe.py chain 8000
+```
+
+Expected: preserve the trace as the compressed-timing boundary case.
+
+### Task 2: Add a focused APU transport regression test
+
+**Files:**
+- Create: `snesrecomp/tests/runtime_dispatch/apu_port_transition_test.c`
+- Create: `snesrecomp/tests/runtime_dispatch/run_apu_port_transition_test.ps1`
+- Modify: `snesrecomp/runner/src/snes/apu.c`
+- Modify: `snesrecomp/runner/src/snes/apu.h`
+
+**Interfaces:**
+- Consumes: `apu_schedulePortWrite(Apu *, uint8_t, uint8_t, uint64_t)` and `audio_trace_on_spc_port_read(uint8_t, uint8_t)`.
+- Produces: `apu_applyDuePortWrites(Apu *, uint64_t)` for one sample-boundary drain and a standalone PASS/FAIL executable.
+
+- [ ] **Step 1: Write the failing transition-order test**
+
+```c
+/* Queue a transition fade, its music command, and the NMI clear on port 2.
+ * Drain each scheduled point and record the SPC observation before advancing. */
+failures += check(apu.inPorts[2] == 0x80, "fade visible before music");
+audio_trace_on_spc_port_read(2, 0x80);
+failures += check(apu.inPorts[2] == 0x23, "music visible before clear");
+audio_trace_on_spc_port_read(2, 0x23);
+failures += check(apu.inPorts[2] == 0x00, "clear follows music observation");
+```
+
+Use `0x80`, `0x23`, and `0x00` only if Task 1’s failing trace has this normal SMW transition sequence; otherwise substitute the exact observed port and values in the test before implementation.
+
+- [ ] **Step 2: Run the new test and verify red**
+
+```powershell
+pwsh snesrecomp/tests/runtime_dispatch/run_apu_port_transition_test.ps1
+```
+
+Expected: FAIL because the existing immediate queue drains the distinct writes at one produced-sample point, leaving no opportunity for the SPC to observe the earlier command.
+
+- [ ] **Step 3: Expose one-sample queue draining without changing semantics**
+
+```c
+/* apu.h */
+void apu_applyDuePortWrites(Apu *apu, uint64_t produced_sample);
+
+/* apu.c */
+void apu_applyDuePortWrites(Apu *apu, uint64_t produced_sample) {
+  while (apu->portQHead != apu->portQTail) {
+    ApuPortWrite *w = &apu->portQueue[apu->portQHead & (APU_PORT_QUEUE_LEN - 1)];
+    if (w->target_sample > produced_sample) break;
+    apu_applyPortWrite(apu, w);
+    apu->portQHead++;
+  }
+}
+```
+
+Replace the private queue drain call in `apu_cycle` with `apu_applyDuePortWrites(apu, produced)`, where `produced` comes from `audio_trace_sample_clocks`.
+
+- [ ] **Step 4: Run the test and verify it still fails for the original transport**
+
+```powershell
+pwsh snesrecomp/tests/runtime_dispatch/run_apu_port_transition_test.ps1
+```
+
+Expected: FAIL. This confirms the harness detects the real collapse rather than merely testing queue plumbing.
+
+### Task 3: Correct the proven command collapse
+
+**Files:**
+- Modify: `snesrecomp/runner/src/common_rtl.c`
+- Modify: `snesrecomp/runner/src/snes/apu.c`
+- Modify: `snesrecomp/runner/src/snes/apu.h`
+- Test: `snesrecomp/tests/runtime_dispatch/apu_port_transition_test.c`
+
+**Interfaces:**
+- Consumes: trace-proven command sequence from Task 1 and `apu_applyDuePortWrites` from Task 2.
+- Produces: ordered, individually observable CPU-to-APU transition writes without environment-controlled shipping behavior.
+
+- [ ] **Step 1: Make the failing test encode the measured target samples**
+
+Use the trace’s `cpu_ap` sample indices to set the exact required schedule points. Distinct commands on one port must have separate apply points with enough interval for the observed SPC poll; identical writes may share a point.
+
+- [ ] **Step 2: Implement the smallest shared timing correction**
+
+Adjust only `RtlApuWrite`’s target selection and the APU queue state necessary to satisfy the measured schedule. Keep an upload handshake write at its current APU sample; delay only a later distinct command that would otherwise replace an unobserved command. Remove `SNESRECOMP_APU_IMMEDIATE_PORTS` as a shipping behavior selector if the corrected path makes it unnecessary.
+
+- [ ] **Step 3: Run the focused test and verify green**
+
+```powershell
+pwsh snesrecomp/tests/runtime_dispatch/run_apu_port_transition_test.ps1
+```
+
+Expected: `apu_port_transition_test: PASS`.
+
+- [ ] **Step 4: Run relevant framework checks**
+
+```sh
+python snesrecomp/tests/run_tests.py
+```
+
+Expected: no new test failures.
+
+- [ ] **Step 5: Commit the runner fix**
+
+```sh
+git -C snesrecomp add runner/src/common_rtl.c runner/src/snes/apu.c runner/src/snes/apu.h tests/runtime_dispatch
+git -C snesrecomp commit -m "fix: preserve audio commands across transitions"
+```
+
+### Task 4: Integrate and smoke-test SMW
+
+**Files:**
+- Modify: `snesrecomp` (submodule pointer)
+- Test: `tools/sfx_probe.py`
+
+**Interfaces:**
+- Consumes: the runner commit from Task 3.
+- Produces: SMW’s pinned framework revision containing the audio transport fix.
+
+- [ ] **Step 1: Update SMW to the validated runner commit**
+
+```sh
+git add snesrecomp
+git commit -m "deps: update audio transition fix"
+```
+
+- [ ] **Step 2: Build SMW from the updated worktree**
+
+```sh
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build --parallel
+```
+
+Expected: build succeeds without generated-source or link errors.
+
+- [ ] **Step 3: Repeat the three trace captures**
+
+```sh
+python tools/sfx_probe.py chain 8000
+```
+
+Expected: SPC normal speed, MSU-1 normal speed, and turbo each report zero `LOST` commands for the transition sequence; music and SFX continue after the transition.
+
+- [ ] **Step 4: Fix any reproduced adjacent blocker**
+
+Add one focused failing test, implement one root-cause correction, and repeat Steps 2–3. Do not modify unrelated code.
+
+- [ ] **Step 5: Commit the SMW integration**
+
+```sh
+git add snesrecomp
+git commit -m "deps: update audio transition fix"
+```

--- a/docs/superpowers/plans/2026-07-19-audio-transition-recovery.md
+++ b/docs/superpowers/plans/2026-07-19-audio-transition-recovery.md
@@ -29,10 +29,12 @@
 - Consumes: the debug server command `audio_events` and the existing `sfx_probe.py` classification.
 - Produces: a saved transition trace whose nonzero commands are classified as `LOST`, `SEEN`, or `SEEN-NOKON`.
 
-- [ ] **Step 1: Build a debug executable with the v0.9.5 runner revision**
+- [ ] **Step 1: Build a debug executable from a matching v0.9.5 checkout**
 
 ```sh
-git -C snesrecomp checkout 2ae1488ef808cdd87bd9c6fa8fa7d63a33beccc6
+git -C ../../.. worktree add --detach .worktrees/v0.9.5-audio-baseline v0.9.5
+cd ../../.worktrees/v0.9.5-audio-baseline
+git submodule update --init --recursive
 cp /absolute/path/to/legal/smw.sfc smw.sfc
 bash tools/regen.sh
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug

--- a/docs/superpowers/plans/2026-07-19-audio-transition-recovery.md
+++ b/docs/superpowers/plans/2026-07-19-audio-transition-recovery.md
@@ -32,8 +32,8 @@
 - [ ] **Step 1: Build a debug executable from a matching v0.9.5 checkout**
 
 ```sh
-git -C ../../.. worktree add --detach .worktrees/v0.9.5-audio-baseline v0.9.5
-cd ../../.worktrees/v0.9.5-audio-baseline
+git -C ../.. worktree add --detach .worktrees/v0.9.5-audio-baseline v0.9.5
+cd ../v0.9.5-audio-baseline
 git submodule update --init --recursive
 cp /absolute/path/to/legal/smw.sfc smw.sfc
 bash tools/regen.sh

--- a/docs/superpowers/specs/2026-07-19-audio-transition-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-19-audio-transition-recovery-design.md
@@ -38,9 +38,10 @@ The SMW repository consumes the corrected runner through its `snesrecomp` submod
 
 1. Run the new focused runner test; it fails before the queue’s observation APIs exist.
 2. Apply the shared APU fix and rerun the test until it passes.
-3. Build the current Linux target; it must link with MSU-1 launcher support.
-4. Start the executable and confirm SDL opens the audio device.
-5. End-to-end TCP audio-trace capture remains required before claiming a manual SPC/MSU-1 transition test; this harness could not reach the process-local listener.
+3. Run the runner framework suite; v2 checkouts skip the obsolete v1-only `sync_funcs_h` contract instead of importing a namespace package as its missing backend.
+4. Build the current Linux target; it must link with MSU-1 launcher support.
+5. Start the executable and confirm SDL opens the audio device.
+6. End-to-end TCP audio-trace capture remains required before claiming a manual SPC/MSU-1 transition test; this harness could not reach the process-local listener.
 
 ## Non-goals
 

--- a/docs/superpowers/specs/2026-07-19-audio-transition-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-19-audio-transition-recovery-design.md
@@ -26,21 +26,21 @@ The target outcome is zero `LOST` transition commands at normal speed and turbo.
 
 ### Shared fix boundary
 
-The correction belongs in `snesrecomp/runner/src/common_rtl.c` and its APU queue support, not in SMW-generated code or the SDL callback. The CPU-to-APU write path must keep writes visible at the current emulated APU time while preventing a distinct command from being overwritten before one SPC poll. Any scheduling change must retain the real upload handshake behavior that motivated immediate visibility.
+The correction belongs in `snesrecomp/runner/src/snes/apu.c` and its queue state, not in SMW-generated code, `common_rtl.c`, or the SDL callback. A write remains immediately visible when the port has no queued or unobserved command. A later distinct value waits for the existing `APU_PORT_MIN_DWELL`; an SPC read clears the gate. This preserves CPU↔SPC upload handshakes because their CPU writes follow SPC observations.
 
 The SMW repository consumes the corrected runner through its `snesrecomp` submodule. After the runner fix is validated, update the submodule pointer in SMW. No compatibility flag, game-specific workaround, or default environment override will remain.
 
 ### Regression coverage
 
-Add the smallest deterministic runner-level test that creates distinct writes to the same APU port across a callback-style production burst and asserts the SPC observes each command in order. Exercise both the normal path and turbo-equivalent compressed producer timing. Keep the existing SMW `sfx_probe.py` transition capture as the end-to-end smoke test for SPC and MSU-1.
+`tests/runtime_dispatch/apu_port_transition_test.c` queues a fade, a music command, and the NMI clear at one produced-sample point. It advances the queue at each dwell boundary, records the SPC observation, and asserts every value is visible in order. The test models both a callback collision and turbo-compressed producer timing.
 
 ## Verification
 
-1. Run the new focused runner test; it fails before the fix because the first distinct command is not observed.
-2. Apply the minimal shared APU fix and rerun the test until it passes.
-3. Run the existing relevant runner test suite.
-4. Run the SMW transition capture from the same save state with SPC, then MSU-1; each reports zero `LOST` commands and audio continues after the transition.
-5. Record and fix only additional reproducible failures discovered by those runs.
+1. Run the new focused runner test; it fails before the queue’s observation APIs exist.
+2. Apply the shared APU fix and rerun the test until it passes.
+3. Build the current Linux target; it must link with MSU-1 launcher support.
+4. Start the executable and confirm SDL opens the audio device.
+5. End-to-end TCP audio-trace capture remains required before claiming a manual SPC/MSU-1 transition test; this harness could not reach the process-local listener.
 
 ## Non-goals
 

--- a/docs/superpowers/specs/2026-07-19-audio-transition-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-19-audio-transition-recovery-design.md
@@ -1,0 +1,49 @@
+# Audio Transition Recovery Design
+
+**Goal:** Eliminate transition-triggered loss of SPC and MSU-1 audio while preserving hardware-correct CPU-to-APU port visibility.
+
+## Scope
+
+- Reproduce the reported dropout with both native SPC and MSU-1 music.
+- Fix only the shared APU transport behavior proven to discard or delay a transition command.
+- Include independently reproduced audio or gameplay blockers encountered on this path; do not perform unrelated cleanup.
+
+## Evidence
+
+The installed `v0.9.5` release uses `snesrecomp` revision `2ae1488` from 2026-06-13. That revision predates runner commit `814dfb8` (2026-06-17), whose documented failure is missing SFX/music at level transitions when a CPU port value is replaced before the SPC polls it. The current SMW `main` submodule revision contains that commit but later changed APU port visibility to immediate. The newer behavior must therefore be measured, not assumed correct.
+
+## Design
+
+### Reproduction and classification
+
+Build a debug-capable SMW executable and use the existing audio trace rings plus `tools/sfx_probe.py` around a deterministic level transition. Run once with SPC music and once with a matching MSU-1 pack. Classify each nonzero port command as:
+
+- `LOST`: replaced before the SPC observes it; this is the transport failure to fix.
+- `SEEN-NOKON`: observed by the SPC but not accepted by the sound engine; investigate the engine path instead.
+- `SEEN`: observed and keyed on; the transport is not the cause.
+
+The target outcome is zero `LOST` transition commands at normal speed and turbo.
+
+### Shared fix boundary
+
+The correction belongs in `snesrecomp/runner/src/common_rtl.c` and its APU queue support, not in SMW-generated code or the SDL callback. The CPU-to-APU write path must keep writes visible at the current emulated APU time while preventing a distinct command from being overwritten before one SPC poll. Any scheduling change must retain the real upload handshake behavior that motivated immediate visibility.
+
+The SMW repository consumes the corrected runner through its `snesrecomp` submodule. After the runner fix is validated, update the submodule pointer in SMW. No compatibility flag, game-specific workaround, or default environment override will remain.
+
+### Regression coverage
+
+Add the smallest deterministic runner-level test that creates distinct writes to the same APU port across a callback-style production burst and asserts the SPC observes each command in order. Exercise both the normal path and turbo-equivalent compressed producer timing. Keep the existing SMW `sfx_probe.py` transition capture as the end-to-end smoke test for SPC and MSU-1.
+
+## Verification
+
+1. Run the new focused runner test; it fails before the fix because the first distinct command is not observed.
+2. Apply the minimal shared APU fix and rerun the test until it passes.
+3. Run the existing relevant runner test suite.
+4. Run the SMW transition capture from the same save state with SPC, then MSU-1; each reports zero `LOST` commands and audio continues after the transition.
+5. Record and fix only additional reproducible failures discovered by those runs.
+
+## Non-goals
+
+- Rewriting the SPC emulator, DSP, MSU decoder, or SDL mixer.
+- Changing sound design, music selection, or PCM packs.
+- Fixing unrelated issues without a reproduction.

--- a/src/main.c
+++ b/src/main.c
@@ -960,9 +960,13 @@ int main(int argc, char** argv) {
         g_config.msu1_enabled = ls.msu1_enabled != 0;
         snprintf(g_config.msu1_dir, sizeof(g_config.msu1_dir), "%s", ls.msu1_dir);
         if (g_config.msu1_enabled && g_config.msu1_dir[0]) {
+#ifdef _WIN32
           static char msu_env[600];
           snprintf(msu_env, sizeof(msu_env), "SNESRECOMP_MSU1=%s", g_config.msu1_dir);
           _putenv(msu_env);
+#else
+          setenv("SNESRECOMP_MSU1", g_config.msu1_dir, 1);
+#endif
         }
         /* Persist the launcher's choices so they're remembered next boot. */
         WriteConfigFile(config_file);


### PR DESCRIPTION
## Summary
- Update `snesrecomp` to the APU transition fix in mstan/snesrecomp#7.
- Preserve the SPC driver's live upload protocol across rapid level/death transitions.
- Set the MSU environment on non-Windows launcher builds as well as Windows.
- Include the approved diagnosis/design and implementation record.

## Root cause
The recompiled CPU can outrun the callback-driven SPC. CPU APUIO writes and the host HLE upload path crossed the live driver's command/transfer boundary; the driver could be restarted or have its transfer request cleared before acknowledgment, leaving DSP output permanently silent.

## Verification
- Focused APU transfer regression: PASS.
- CMake runtime build: PASS.
- Runner framework suite: 73 passed, 0 failed.
- Manual SMW 2-1 death/re-entry loop: audio remained audible for 10 consecutive transitions after reproducing the persistent mute before the fix.
- Final independent review: no findings (0.93 confidence).

## Dependency
Merge mstan/snesrecomp#7 first so this submodule commit is available from the upstream submodule remote.