### PR TITLE
fix: preserve SMW sound effect commands

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1011,6 +1011,20 @@ int main(int argc, char** argv) {
   argc = 1;
   host_report_breadcrumb("rom resolved: %s", rom_path_buf);
 
+  /* SMW sends one-frame SFX commands followed by a zero clear. Immediate
+   * host-time port writes can let that clear overtake the SPC's next poll
+   * when the 60.0988 Hz NMI crosses the 60 Hz audio-callback phase. Use the
+   * existing deferred scheduler by default; keep the env override for
+   * diagnostics and alternate timing experiments. */
+  if (!getenv("SNESRECOMP_APU_IMMEDIATE_PORTS")) {
+#ifdef _WIN32
+    static char apu_ports_env[] = "SNESRECOMP_APU_IMMEDIATE_PORTS=0";
+    _putenv(apu_ports_env);
+#else
+    setenv("SNESRECOMP_APU_IMMEDIATE_PORTS", "0", 0);
+#endif
+  }
+
   /* Honor the persisted MSU-1 choice on every boot path — launcher, SkipLauncher,
    * positional ROM, SNESRECOMP_NO_LAUNCHER. The launcher exports this when it runs;
    * doing it here too means a launcher-skipping boot still streams MSU-1 if the


### PR DESCRIPTION
## Summary
- default SMW to the existing deferred APU-port scheduler
- prevent one-frame SFX commands from being cleared before the SPC polls them
- preserve `SNESRECOMP_APU_IMMEDIATE_PORTS` as an explicit diagnostic override

## Root cause
SMW writes a nonzero SFX command for one frame, then clears the port. With immediate host-time writes, the 60.0988 Hz NMI can cross the 60 Hz audio-callback phase and leave the command visible for less than one SPC polling interval.

## Verification
- reproduced with the always-on audio trace: immediate mode delivered 31/32 SFX commands; the lost command was cleared after 165 native samples before any SPC read
- fixed default delivered 52/52 SFX commands with 0 lost
- `bash tools/build-linux.sh --config debug --no-package --jobs 8`
- `bash tools/build-linux.sh --config prod --no-package --jobs 8`
- production smoke test entered the main loop with the 39-track MSU pack active and a PCM stream open

Focused code review found no blocking issues.