### PR TITLE
audio: adopt guest-timed APU synchronization

### DIFF
--- a/recomp/bank00.cfg
+++ b/recomp/bank00.cfg
@@ -38,7 +38,7 @@ exclude_range 806B 8079
 # result, but in microseconds instead of seconds. The recompiled
 # parents (UploadSPCEngine, UploadSamples, etc.) keep their original
 # bodies; only the inner SPC700UploadLoop body is HLE'd.
-hle_spc_upload 8079
+hle_spc_upload 8079 live
 
 
 # --- Function entries (300) ---

--- a/src/main.c
+++ b/src/main.c
@@ -1431,6 +1431,29 @@ error_reading:;
       if (s_ft < 0) { const char *e = getenv("SNESRECOMP_FORCE_TURBO");
                       s_ft = (e && e[0] && e[0] != '0') ? 1 : 0; }
       if (s_ft) g_turbo = 1; }
+    /* Process-local finite turbo stress. Unlike synthetic keyboard input this
+     * cannot leak into another running recomp. Format is start_frame,count;
+     * it is dev-only and inert unless explicitly configured. */
+    { static int s_start = -2, s_end = -2;
+      if (s_start == -2) {
+        const char *e = getenv("SNESRECOMP_TURBO_BURST");
+        int start = -1, count = 0;
+        if (e && sscanf(e, "%d,%d", &start, &count) == 2 &&
+            start >= 0 && count > 0) {
+          s_start = start;
+          s_end = start + count;
+        } else {
+          s_start = s_end = -1;
+        }
+      }
+      if (s_start >= 0) {
+        if (frameCtr >= (uint32)s_start && frameCtr < (uint32)s_end)
+          g_turbo = 1;
+        else if (frameCtr == (uint32)s_end)
+          g_turbo = 0;
+      }
+    }
+    RtlAudioSetFastForward(g_turbo != 0);
     g_snes->disableRender = g_turbo && (frameCtr & 0xf) != 0;
 
     if (!g_snes->disableRender) {


### PR DESCRIPTION
## Summary

- pin the shared engine merge from mstan/snesrecomp#8
- declare SMW's runtime SPC upload as the protocol-preserving `live` mode
- report turbo state to the shared audio runtime every frame
- add an inert, process-local `SNESRECOMP_TURBO_BURST=start,count` validation hook

This replaces the short-term port-timing workaround in #8 and the audio portion of #7 with the measured guest-time solution. The non-Windows MSU launcher portion of #7 is independent and is not included here.

## Validation

- trace-free build succeeds against engine `f3698bd`
- normal audio rate: ~32.18k samples/s, no accumulating queue lag or underflows
- turbo release keeps the queue current rather than playing stale PCM
- ear pass: normal play, Yoshi/jump SFX, level loads, repeated turbo transitions, and post-turbo persistence